### PR TITLE
refactor: bundle @ffmpeg/core instead of CDN

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "vite-plugin-static-copy": "^1.0.6"
   },
   "dependencies": {
+    "@ffmpeg/core": "^0.12.6",
     "@ffmpeg/ffmpeg": "^0.12.10",
-    "@ffmpeg/util": "^0.12.1",
     "@sentry/browser": "^7.110.0",
     "canvas-confetti": "^1.9.2",
     "json5": "^2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,12 +16,12 @@ importers:
 
   .:
     dependencies:
+      '@ffmpeg/core':
+        specifier: ^0.12.6
+        version: 0.12.6
       '@ffmpeg/ffmpeg':
         specifier: ^0.12.10
         version: 0.12.10(patch_hash=rp32kszgnosraou7uzgtdqueci)
-      '@ffmpeg/util':
-        specifier: ^0.12.1
-        version: 0.12.1
       '@sentry/browser':
         specifier: ^7.110.0
         version: 7.110.0
@@ -384,6 +384,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ffmpeg/core@0.12.6':
+    resolution: {integrity: sha512-PrjWBTfGn2WVn9T7wGnzfFwChbqWeZc7tM9vvJZVRadYFUDakfzy7W0LpYC0cvvK0xT82qlBsk38lQhJ/Hps5A==}
+    engines: {node: '>=16.x'}
+
   '@ffmpeg/ffmpeg@0.12.10':
     resolution: {integrity: sha512-lVtk8PW8e+NUzGZhPTWj2P1J4/NyuCrbDD3O9IGpSeLYtUZKBqZO8CNj1WYGghep/MXoM8e1qVY1GztTkf8YYQ==}
     engines: {node: '>=18.x'}
@@ -391,10 +395,6 @@ packages:
   '@ffmpeg/types@0.12.2':
     resolution: {integrity: sha512-NJtxwPoLb60/z1Klv0ueshguWQ/7mNm106qdHkB4HL49LXszjhjCCiL+ldHJGQ9ai2Igx0s4F24ghigy//ERdA==}
     engines: {node: '>=16.x'}
-
-  '@ffmpeg/util@0.12.1':
-    resolution: {integrity: sha512-10jjfAKWaDyb8+nAkijcsi9wgz/y26LOc1NKJradNMyCIl6usQcBbhkjX5qhALrSBcOy6TOeksunTYa+a03qNQ==}
-    engines: {node: '>=18.x'}
 
   '@iconify-json/mdi@1.1.66':
     resolution: {integrity: sha512-7KPF2RVUUWav/hXCM8Ti/smqu3cmgePJpiX9CSkldiL+80+eBRBeKlc4vPOc9jhAItlqIU1vKsbKoPP0JIfgbg==}
@@ -1600,13 +1600,13 @@ snapshots:
   '@esbuild/win32-x64@0.20.2':
     optional: true
 
+  '@ffmpeg/core@0.12.6': {}
+
   '@ffmpeg/ffmpeg@0.12.10(patch_hash=rp32kszgnosraou7uzgtdqueci)':
     dependencies:
       '@ffmpeg/types': 0.12.2
 
   '@ffmpeg/types@0.12.2': {}
-
-  '@ffmpeg/util@0.12.1': {}
 
   '@iconify-json/mdi@1.1.66':
     dependencies:

--- a/src/ffmpeg.ts
+++ b/src/ffmpeg.ts
@@ -1,22 +1,13 @@
 import { FFmpeg } from "@ffmpeg/ffmpeg";
-import { fetchFile, toBlobURL } from '@ffmpeg/util';
 import { updateStore } from "./store";
 import workerURL from '@ffmpeg/ffmpeg/worker?url';
 
 export async function initFFmpeg() {
   let ffmpeg = new FFmpeg()
-  const CORE_VERSION = '0.12.6'
-  const baseURL = 'https://unpkg.com/@ffmpeg/core@' + CORE_VERSION + '/dist/esm'
-
-  // Load the WASM file and coreURL
-  const [coreURL, wasmURL] = await Promise.all([
-    toBlobURL(`${baseURL}/ffmpeg-core.js`, 'text/javascript'),
-    toBlobURL(`${baseURL}/ffmpeg-core.wasm`, 'application/wasm'),
-  ])
 
   await ffmpeg.load({
-    coreURL,
-    wasmURL,
+    coreURL: './ffmpeg-core.js',
+    wasmURL: './ffmpeg-core.wasm',
     classWorkerURL: import.meta.env.PROD ? undefined : workerURL, // vite bug
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,12 @@ export default defineConfig({
     devtools(),
     solidPlugin(),
     viteStaticCopy({
-      targets: [{ src: './LICENSE', dest: './' }]
+      targets: [
+        { src: './LICENSE', dest: './' },
+
+        { src: './node_modules/@ffmpeg/core/dist/esm/ffmpeg-core.js', dest: './assets' },
+        { src: './node_modules/@ffmpeg/core/dist/esm/ffmpeg-core.wasm', dest: './assets' },
+      ]
     })
   ],
   server: {


### PR DESCRIPTION
- improves security in case the CDN goes malicious,
- reliability against the CDN going down or being unavailable
- allows to use the app with no / limited internet access, such as the context of browser extensions

There might be a more direct, "Vite-way" to do this, but this works: https://wofwca.github.io/video-to-gif/